### PR TITLE
Adding a title to post/ and 404

### DIFF
--- a/404.md
+++ b/404.md
@@ -1,3 +1,7 @@
++++
+title = "404"
++++
+
 # 404: File not found
 
 The requested file was not found.

--- a/post/index.md
+++ b/post/index.md
@@ -1,4 +1,5 @@
 +++
+title = "Blog"
 external_entries = [
     (
       Date(2020, 1, 14),


### PR DESCRIPTION
I realised while linking to JuliaGPU as an example of how to set RSS that a link to `/post/` showed up as 

---

<img width="299" alt="Screenshot 2022-03-11 at 11 15 53" src="https://user-images.githubusercontent.com/10897531/157847891-3ebed74b-0c29-437b-8ba6-c2dc80003ca5.png">

---

this is because in layout there is this `{{title}} . JuliaGPU` and when `title` is not defined, it just becomes `. JuliaGPU`. 
