### PR TITLE
Host CUDA blog-posts in juliagpu.org again.

### DIFF
--- a/post/2023-09-19-cuda_5.0.md
+++ b/post/2023-09-19-cuda_5.0.md
@@ -10,10 +10,6 @@ abstract = """
 
 {{abstract}}
 
-{{ redirect "https://info.juliahub.com/cuda-jl-5-0-changes" }}
-
-
-<!--
 
 ## Integrated profiler
 
@@ -178,5 +174,3 @@ toolkit, you will automatically get the latest version supported by your CUDA dr
   [`gemv`](https://github.com/JuliaGPU/CUDA.jl/pull/1981) and
   [`svd`](https://github.com/JuliaGPU/CUDA.jl/pull/2063) (by
   [@lpawela](https://github.com/lpawela) and [@nikopj](https://github.com/nikopj).
-
--->

--- a/post/2023-11-07-cuda_5.1.md
+++ b/post/2023-11-07-cuda_5.1.md
@@ -10,10 +10,6 @@ abstract = """
 
 {{abstract}}
 
-{{ redirect "https://info.juliahub.com/cuda-jl-5-1-unified-memory" }}
-
-<!--
-
 # CUDA.jl 5.1: Unified memory and cooperative groups
 
 CUDA.jl 5.1 greatly improves the support of two important parts of the CUDA toolkit: unified
@@ -206,5 +202,3 @@ Apart from these two major features, CUDA.jl 5.1 also includes a number of small
 - Improvements to the native profiler (`CUDA.@profiler`), now also showing local memory
   usage, supporting more NVTX metadata, and with better support for Pluto.jl and Jupyter
 - Many CUSOLVER and CUSPARSE improvements by [@amontoison](https://github.com/amontoison)
-
--->


### PR DESCRIPTION
The posts on juliahub.com have gone offline already.