### PR TITLE
Redesign site with modern theme and updated dependencies

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install Julia
       uses: julia-actions/setup-julia@v1
       with:
-        version: 1.9
+        version: '1.12'
 
     - name: Fix URLs for PR preview deployment (pull request previews)
       if: github.event_name == 'pull_request'

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,27 +1,47 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.9.4"
+julia_version = "1.12.6"
 manifest_format = "2.0"
-project_hash = "f3d8e2ab8b29445a93b1b16df38a062765d4d8f3"
+project_hash = "b111b7dd984cad0d337dca11750dc8cb1d3d738d"
 
 [[deps.ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
-version = "1.1.1"
+version = "1.1.2"
 
 [[deps.Artifacts]]
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+version = "1.11.0"
 
 [[deps.Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+version = "1.11.0"
 
-[[deps.Crayons]]
-git-tree-sha1 = "3f71217b538d7aaee0b69ab47d9b7724ca8afa0d"
-uuid = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
-version = "4.0.4"
+[[deps.BitFlags]]
+git-tree-sha1 = "0691e34b3bb8be9307330f88d1a3c3f25466c24d"
+uuid = "d1d4a3ce-64b1-5f1a-9ba4-7e7e69966f35"
+version = "0.1.9"
+
+[[deps.CodecZlib]]
+deps = ["TranscodingStreams", "Zlib_jll"]
+git-tree-sha1 = "962834c22b66e32aa10f7611c08c8ca4e20749a9"
+uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
+version = "0.7.8"
+
+[[deps.CompilerSupportLibraries_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+version = "1.3.0+1"
+
+[[deps.ConcurrentUtilities]]
+deps = ["Serialization", "Sockets"]
+git-tree-sha1 = "21d088c496ea22914fe80906eb5bce65755e5ec8"
+uuid = "f0e56b4a-5159-44fe-b623-3e5288b988bb"
+version = "2.5.1"
 
 [[deps.Dates]]
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+version = "1.11.0"
 
 [[deps.DelimitedFiles]]
 deps = ["Mmap"]
@@ -30,63 +50,81 @@ uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 version = "1.9.1"
 
 [[deps.DocStringExtensions]]
-deps = ["LibGit2"]
-git-tree-sha1 = "a32185f5428d3986f47c2ab78b1f216d5e6cc96f"
+git-tree-sha1 = "7442a5dfe1ebb773c29cc2962a8980f47221d76c"
 uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-version = "0.8.5"
+version = "0.9.5"
 
 [[deps.Downloads]]
 deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
 uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
-version = "1.6.0"
+version = "1.7.0"
+
+[[deps.ExceptionUnwrapping]]
+deps = ["Test"]
+git-tree-sha1 = "d36f682e590a83d63d1c7dbd287573764682d12a"
+uuid = "460bff9d-24e4-43bc-9d9f-a8973cb893f4"
+version = "0.1.11"
 
 [[deps.ExprTools]]
-git-tree-sha1 = "b7e3d17636b348f005f11040025ae8c6f645fe92"
+git-tree-sha1 = "27415f162e6028e81c72b82ef756bf321213b6ec"
 uuid = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
-version = "0.1.6"
+version = "0.1.10"
 
 [[deps.FileWatching]]
 uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
+version = "1.11.0"
 
 [[deps.Franklin]]
-deps = ["Dates", "DelimitedFiles", "DocStringExtensions", "ExprTools", "FranklinTemplates", "HTTP", "Literate", "LiveServer", "Logging", "Markdown", "NodeJS", "OrderedCollections", "Pkg", "REPL", "Random"]
-git-tree-sha1 = "ca57f7e99cb91d90fa8f969bbc7ffda3b7e09a12"
+deps = ["Dates", "DelimitedFiles", "DocStringExtensions", "ExprTools", "FranklinTemplates", "HTTP", "Literate", "LiveServer", "Logging", "Markdown", "NodeJS", "OrderedCollections", "Pkg", "REPL", "Random", "TOML"]
+git-tree-sha1 = "717c8b1bfc0278870ab82fbe69119ee8449290c6"
 uuid = "713c75ef-9fc9-4b05-94a9-213340da978e"
-version = "0.10.59"
+version = "0.10.97"
 
 [[deps.FranklinTemplates]]
 deps = ["LiveServer"]
-git-tree-sha1 = "20ec221753e0c6bcac845423089b656538ac4eec"
+git-tree-sha1 = "d133c84067f715bed4bb9113a931e88fd668ea63"
 uuid = "3a985190-f512-4703-8d38-2a7944ed5916"
-version = "0.8.22"
+version = "0.10.3"
 
 [[deps.HTTP]]
-deps = ["Base64", "Dates", "IniFile", "Logging", "MbedTLS", "NetworkOptions", "Sockets", "URIs"]
-git-tree-sha1 = "14eece7a3308b4d8be910e265c724a6ba51a9798"
+deps = ["Base64", "CodecZlib", "ConcurrentUtilities", "Dates", "ExceptionUnwrapping", "Logging", "LoggingExtras", "MbedTLS", "NetworkOptions", "OpenSSL", "PrecompileTools", "Random", "SimpleBufferStream", "Sockets", "URIs", "UUIDs"]
+git-tree-sha1 = "51059d23c8bb67911a2e6fd5130229113735fc7e"
 uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
-version = "0.9.16"
+version = "1.11.0"
 
 [[deps.IOCapture]]
 deps = ["Logging", "Random"]
-git-tree-sha1 = "f7be53659ab06ddc986428d3a9dcc95f6fa6705a"
+git-tree-sha1 = "0ee181ec08df7d7c911901ea38baf16f755114dc"
 uuid = "b5f81e59-6552-4d32-b1f0-c071b021bf89"
-version = "0.2.2"
-
-[[deps.IniFile]]
-deps = ["Test"]
-git-tree-sha1 = "098e4d2c533924c921f9f9847274f2ad89e018b8"
-uuid = "83e8ac13-25f8-5344-8a64-a9f2b223428f"
-version = "0.5.0"
+version = "1.0.0"
 
 [[deps.InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+version = "1.11.0"
+
+[[deps.JLLWrappers]]
+deps = ["Artifacts", "Preferences"]
+git-tree-sha1 = "0533e564aae234aff59ab625543145446d8b6ec2"
+uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
+version = "1.7.1"
 
 [[deps.JSON]]
-deps = ["Dates", "Mmap", "Parsers", "Unicode"]
-git-tree-sha1 = "8076680b162ada2a031f707ac7b4953e30667a37"
+deps = ["Dates", "Logging", "Parsers", "PrecompileTools", "StructUtils", "UUIDs", "Unicode"]
+git-tree-sha1 = "67c6f1f085cb2671c93fe34244c9cccde30f7a26"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-version = "0.21.2"
+version = "1.5.0"
+
+    [deps.JSON.extensions]
+    JSONArrowExt = ["ArrowTypes"]
+
+    [deps.JSON.weakdeps]
+    ArrowTypes = "31f734f8-188a-4ce0-8406-c8a06bd891cd"
+
+[[deps.JuliaSyntaxHighlighting]]
+deps = ["StyledStrings"]
+uuid = "ac6e5ff7-fb65-4e79-a425-ec3bc9c03011"
+version = "1.12.0"
 
 [[deps.LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]
@@ -94,96 +132,148 @@ uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
 version = "0.6.4"
 
 [[deps.LibCURL_jll]]
-deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "OpenSSL_jll", "Zlib_jll", "nghttp2_jll"]
 uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
-version = "8.4.0+0"
+version = "8.15.0+0"
 
 [[deps.LibGit2]]
-deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
+deps = ["LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+version = "1.11.0"
+
+[[deps.LibGit2_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "OpenSSL_jll"]
+uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
+version = "1.9.0+0"
 
 [[deps.LibSSH2_jll]]
-deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+deps = ["Artifacts", "Libdl", "OpenSSL_jll"]
 uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
-version = "1.11.0+1"
+version = "1.11.3+1"
 
 [[deps.Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+version = "1.11.0"
 
 [[deps.Literate]]
 deps = ["Base64", "IOCapture", "JSON", "REPL"]
-git-tree-sha1 = "bbebc3c14dbfbe76bfcbabf0937481ac84dc86ef"
+git-tree-sha1 = "bb26d8b8ed0fa451ce3511e99c950653a2f31fe1"
 uuid = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
-version = "2.9.3"
+version = "2.21.0"
 
 [[deps.LiveServer]]
-deps = ["Crayons", "FileWatching", "HTTP", "Pkg", "Sockets", "Test"]
-git-tree-sha1 = "99990da121ad310875b3c4dba5954eba54df8cfd"
+deps = ["HTTP", "LoggingExtras", "MIMEs", "Sockets", "Test"]
+git-tree-sha1 = "9f65b8a9989e6acb6e216785dd0c748d9569fc9b"
 uuid = "16fef848-5104-11e9-1b77-fb7a48bbb589"
-version = "0.7.0"
+version = "1.5.0"
 
 [[deps.Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+version = "1.11.0"
+
+[[deps.LoggingExtras]]
+deps = ["Dates", "Logging"]
+git-tree-sha1 = "f00544d95982ea270145636c181ceda21c4e2575"
+uuid = "e6f89c97-d47a-5376-807f-9c37f3926c36"
+version = "1.2.0"
+
+[[deps.MIMEs]]
+git-tree-sha1 = "65f28ad4b594aebe22157d6fac869786a255b7eb"
+uuid = "6c6e2e6c-3030-632d-7369-2d6c69616d65"
+version = "0.1.4"
 
 [[deps.Markdown]]
-deps = ["Base64"]
+deps = ["Base64", "JuliaSyntaxHighlighting", "StyledStrings"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+version = "1.11.0"
 
 [[deps.MbedTLS]]
-deps = ["Dates", "MbedTLS_jll", "Random", "Sockets"]
-git-tree-sha1 = "1c38e51c3d08ef2278062ebceade0e46cefc96fe"
+deps = ["Dates", "MbedTLS_jll", "MozillaCACerts_jll", "NetworkOptions", "Random", "Sockets"]
+git-tree-sha1 = "8785729fa736197687541f7053f6d8ab7fc44f92"
 uuid = "739be429-bea8-5141-9913-cc70e7f3736d"
-version = "1.0.3"
+version = "1.1.10"
 
 [[deps.MbedTLS_jll]]
-deps = ["Artifacts", "Libdl"]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "ff69a2b1330bcb730b9ac1ab7dd680176f5896b8"
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
-version = "2.28.2+0"
+version = "2.28.1010+0"
 
 [[deps.Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+version = "1.11.0"
 
 [[deps.MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
-version = "2022.10.11"
+version = "2025.11.4"
 
 [[deps.NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
-version = "1.2.0"
+version = "1.3.0"
 
 [[deps.NodeJS]]
 deps = ["Pkg"]
-git-tree-sha1 = "905224bbdd4b555c69bb964514cfa387616f0d3a"
+git-tree-sha1 = "bf1f49fd62754064bc42490a8ddc2aa3694a8e7a"
 uuid = "2bd173c7-0d6d-553b-b6af-13a54713934c"
-version = "1.3.0"
+version = "2.0.0"
+
+[[deps.OpenSSL]]
+deps = ["BitFlags", "Dates", "MozillaCACerts_jll", "NetworkOptions", "OpenSSL_jll", "Sockets"]
+git-tree-sha1 = "1d1aaa7d449b58415f97d2839c318b70ffb525a0"
+uuid = "4d8831e6-92b7-49fb-bdf8-b643e874388c"
+version = "1.6.1"
+
+[[deps.OpenSSL_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
+version = "3.5.4+0"
 
 [[deps.OrderedCollections]]
-git-tree-sha1 = "85f8e6578bf1f9ee0d11e7bb1b1456435479d47c"
+git-tree-sha1 = "05868e21324cede2207c6f0f466b4bfef6d5e7ee"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
-version = "1.4.1"
+version = "1.8.1"
 
 [[deps.Parsers]]
-deps = ["Dates"]
-git-tree-sha1 = "a8709b968a1ea6abc2dc1967cb1db6ac9a00dfb6"
+deps = ["Dates", "PrecompileTools", "UUIDs"]
+git-tree-sha1 = "7d2f8f21da5db6a806faf7b9b292296da42b2810"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "2.0.5"
+version = "2.8.3"
 
 [[deps.Pkg]]
-deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "Random", "SHA", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-version = "1.9.2"
+version = "1.12.1"
+weakdeps = ["REPL"]
+
+    [deps.Pkg.extensions]
+    REPLExt = "REPL"
+
+[[deps.PrecompileTools]]
+deps = ["Preferences"]
+git-tree-sha1 = "07a921781cab75691315adc645096ed5e370cb77"
+uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+version = "1.3.3"
+
+[[deps.Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "8b770b60760d4451834fe79dd483e318eee709c4"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.5.2"
 
 [[deps.Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+version = "1.11.0"
 
 [[deps.REPL]]
-deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
+deps = ["InteractiveUtils", "JuliaSyntaxHighlighting", "Markdown", "Sockets", "StyledStrings", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+version = "1.11.0"
 
 [[deps.Random]]
-deps = ["SHA", "Serialization"]
+deps = ["SHA"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+version = "1.11.0"
 
 [[deps.SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
@@ -191,9 +281,36 @@ version = "0.7.0"
 
 [[deps.Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+version = "1.11.0"
+
+[[deps.SimpleBufferStream]]
+git-tree-sha1 = "f305871d2f381d21527c770d4788c06c097c9bc1"
+uuid = "777ac1f9-54b0-4bf8-805c-2214025038e7"
+version = "1.2.0"
 
 [[deps.Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+version = "1.11.0"
+
+[[deps.StructUtils]]
+deps = ["Dates", "UUIDs"]
+git-tree-sha1 = "aab80fbf866600f3299dd7f6656d80e7be177cfe"
+uuid = "ec057cc2-7a8d-4b58-b3b3-92acb9f63b42"
+version = "2.7.2"
+
+    [deps.StructUtils.extensions]
+    StructUtilsMeasurementsExt = ["Measurements"]
+    StructUtilsStaticArraysCoreExt = ["StaticArraysCore"]
+    StructUtilsTablesExt = ["Tables"]
+
+    [deps.StructUtils.weakdeps]
+    Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
+    StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+    Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+
+[[deps.StyledStrings]]
+uuid = "f489334b-da3d-4c2e-b8f0-e476e12c162b"
+version = "1.11.0"
 
 [[deps.TOML]]
 deps = ["Dates"]
@@ -208,30 +325,38 @@ version = "1.10.0"
 [[deps.Test]]
 deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+version = "1.11.0"
+
+[[deps.TranscodingStreams]]
+git-tree-sha1 = "0c45878dcfdcfa8480052b6ab162cdd138781742"
+uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
+version = "0.11.3"
 
 [[deps.URIs]]
-git-tree-sha1 = "97bbe755a53fe859669cd907f2d96aee8d2c1355"
+git-tree-sha1 = "bef26fb046d031353ef97a82e3fdb6afe7f21b1a"
 uuid = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
-version = "1.3.0"
+version = "1.6.1"
 
 [[deps.UUIDs]]
 deps = ["Random", "SHA"]
 uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+version = "1.11.0"
 
 [[deps.Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+version = "1.11.0"
 
 [[deps.Zlib_jll]]
 deps = ["Libdl"]
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
-version = "1.2.13+0"
+version = "1.3.1+2"
 
 [[deps.nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
-version = "1.52.0+1"
+version = "1.64.0+1"
 
 [[deps.p7zip_jll]]
-deps = ["Artifacts", "Libdl"]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
 uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
-version = "17.4.0+0"
+version = "17.7.0+0"

--- a/Project.toml
+++ b/Project.toml
@@ -2,5 +2,5 @@
 Franklin = "713c75ef-9fc9-4b05-94a9-213340da978e"
 
 [compat]
-Franklin = "0.10.35"
-julia = "=1.9"
+Franklin = "0.10.97"
+julia = "1.12"

--- a/_css/style.css
+++ b/_css/style.css
@@ -1,55 +1,338 @@
-/* Reduce whitespace around code blocks */
-pre code.hljs {
-   padding: 0;
-   background: 0 0
+/* ===== CSS Custom Properties (Theme) ===== */
+:root {
+  --julia-blue: #4063d8;
+  --julia-green: #389826;
+  --julia-purple: #9558b2;
+  --julia-red: #cb3c33;
+  --gpu-accent: #6c63ff;
+  --gpu-accent-light: #8b83ff;
+
+  --bg-primary: #ffffff;
+  --bg-secondary: #f8f9fa;
+  --bg-code: #f5f5f5;
+  --bg-code-inline: #f0ebf4;
+  --text-primary: #212529;
+  --text-secondary: #6c757d;
+  --text-code-inline: #7c3aed;
+  --border-color: #dee2e6;
+  --nav-border: #212529;
+  --card-bg: #ffffff;
+  --card-border: #dee2e6;
+  --hero-bg: linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%);
+  --hero-text: #ffffff;
+  --footer-bg: #f8f9fa;
+  --footer-text: #6c757d;
+  --code-theme-bg: #282c34;
+  --code-theme-text: #abb2bf;
 }
 
-/* Limit page width */
+[data-bs-theme="dark"] {
+  --bg-primary: #1a1a2e;
+  --bg-secondary: #16213e;
+  --bg-code: #282c34;
+  --bg-code-inline: #2d2640;
+  --text-primary: #e0e0e0;
+  --text-secondary: #a0a0a0;
+  --text-code-inline: #b794f4;
+  --border-color: #2d3748;
+  --nav-border: #4a5568;
+  --card-bg: #16213e;
+  --card-border: #2d3748;
+  --hero-bg: linear-gradient(135deg, #0d0d1a 0%, #111827 50%, #0a1628 100%);
+  --footer-bg: #111827;
+  --footer-text: #a0a0a0;
+}
+
+/* ===== Base ===== */
+body {
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  transition: background-color 0.2s, color 0.2s;
+}
+
+/* ===== Layout ===== */
 .container {
-   max-width: 700px
-}
-
-/* Add line under navigation menu */
-#nav-border {
-   border-bottom: 1px solid #212529
+  max-width: 860px;
 }
 
 #main {
-   margin-top: 1em;
-   margin-bottom: 4em
+  margin-top: 1em;
+  margin-bottom: 4em;
 }
 
-#footer .container {
-   padding: 1em 0
+/* ===== Navigation ===== */
+#nav-border {
+  border-bottom: 1px solid var(--nav-border);
+  background-color: var(--bg-primary);
 }
 
-#footer a {
-   color: inherit;
-   text-decoration: underline
+.navbar {
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
 }
 
-.font-125 {
-   font-size: 125%
+.nav-link {
+  color: var(--text-primary) !important;
+  font-weight: 500;
+  transition: color 0.15s;
 }
 
-.tag-btn {
-   margin-bottom: .3em
+.nav-link:hover,
+.nav-link.active {
+  color: var(--gpu-accent) !important;
+}
+
+.dropdown-menu {
+  background-color: var(--card-bg);
+  border-color: var(--card-border);
+}
+
+.dropdown-item {
+  color: var(--text-primary);
+}
+
+.dropdown-item:hover,
+.dropdown-item.active {
+  background-color: var(--bg-secondary);
+  color: var(--gpu-accent);
+}
+
+.dropdown:hover .dropdown-menu {
+  display: block;
+}
+
+.theme-toggle {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  padding: 0.5rem;
+  font-size: 1.1rem;
+  transition: color 0.15s;
+}
+
+.theme-toggle:hover {
+  color: var(--gpu-accent);
+}
+
+/* ===== Hero Section ===== */
+.hero {
+  background: var(--hero-bg);
+  color: var(--hero-text);
+  padding: 4rem 0 3rem;
+  margin-bottom: 2rem;
+  text-align: center;
+}
+
+.hero h1 {
+  font-size: 2.5rem;
+  font-weight: 700;
+  margin-bottom: 0.75rem;
+}
+
+.hero .lead {
+  font-size: 1.25rem;
+  opacity: 0.9;
+  margin-bottom: 1.5rem;
+}
+
+.hero-code {
+  max-width: 520px;
+  margin: 0 auto;
+  text-align: left;
+}
+
+.hero-code pre {
+  background: rgba(0, 0, 0, 0.4);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  padding: 1.25rem;
+  color: #abb2bf;
+  font-size: 0.9rem;
+  margin: 0;
+  overflow-x: auto;
+}
+
+.hero-code pre code {
+  background: none;
+  color: inherit;
+  padding: 0;
+  font-size: inherit;
+}
+
+/* ===== Code Blocks ===== */
+pre code.hljs {
+  padding: 0;
+  background: 0 0;
 }
 
 pre {
-   background-color: #f5f5f5;
-   border: 1px solid #ccc;
-   border-radius: 4px;
-   padding: 16px
+  background-color: var(--code-theme-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 1rem 1.25rem;
+  color: var(--code-theme-text);
 }
 
-/* Highlight inline code blocks */
 code {
-   padding: 2px 4px;
-   font-size: 90%;
-   color: #c7254e;
-   background-color: #f9f2f4;
-   border-radius: 4px
+  padding: 2px 6px;
+  font-size: 87.5%;
+  color: var(--text-code-inline);
+  background-color: var(--bg-code-inline);
+  border-radius: 4px;
+}
+
+pre code {
+  color: inherit;
+}
+
+/* ===== Cards ===== */
+.card {
+  background-color: var(--card-bg);
+  border-color: var(--card-border);
+  border-radius: 8px;
+  overflow: hidden;
+  transition: transform 0.15s, box-shadow 0.15s;
+}
+
+.card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.card-img,
+.card-img-top,
+.card-img-bottom {
+  width: initial;
+}
+
+.card-body {
+  color: var(--text-primary);
+}
+
+/* ===== Blog Post Cards ===== */
+.blog-entry {
+  border: 1px solid var(--card-border);
+  border-radius: 8px;
+  padding: 1.25rem 1.5rem;
+  margin-bottom: 1rem;
+  background-color: var(--card-bg);
+  transition: transform 0.15s, box-shadow 0.15s;
+}
+
+.blog-entry:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
+.blog-entry a.font-125 {
+  color: var(--gpu-accent);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.blog-entry a.font-125:hover {
+  text-decoration: underline;
+}
+
+.blog-entry time {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+/* ===== Backend Comparison Table ===== */
+.backend-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.5rem 0;
+  font-size: 0.95rem;
+}
+
+.backend-table th,
+.backend-table td {
+  padding: 0.75rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.backend-table thead th {
+  background-color: var(--bg-secondary);
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.backend-table tbody tr:hover {
+  background-color: var(--bg-secondary);
+}
+
+.badge-mature {
+  background-color: var(--julia-green);
+  color: #fff;
+}
+
+.badge-stable {
+  background-color: var(--julia-blue);
+  color: #fff;
+}
+
+.badge-developing {
+  background-color: #f0ad4e;
+  color: #212529;
+}
+
+.badge-early {
+  background-color: var(--text-secondary);
+  color: #fff;
+}
+
+/* ===== Footer ===== */
+#footer {
+  background-color: var(--footer-bg);
+  border-top: 1px solid var(--border-color);
+  padding: 2rem 0;
+  color: var(--footer-text);
+}
+
+#footer .container {
+  padding: 0;
+}
+
+#footer a {
+  color: var(--gpu-accent);
+  text-decoration: none;
+}
+
+#footer a:hover {
+  text-decoration: underline;
+}
+
+.footer-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  justify-content: center;
+  margin-bottom: 1rem;
+  list-style: none;
+  padding: 0;
+}
+
+.footer-links a {
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-size: 0.9rem;
+}
+
+.footer-links a:hover {
+  color: var(--gpu-accent);
+}
+
+/* ===== Utilities ===== */
+.font-125 {
+  font-size: 125%;
+}
+
+.tag-btn {
+  margin-bottom: 0.3em;
 }
 
 img,
@@ -57,25 +340,33 @@ iframe,
 embed,
 video,
 audio {
-   max-width: 100%
+  max-width: 100%;
 }
 
-.card-img,
-.card-img-top,
-.card-img-bottom {
-   width: initial
-}
-
-#main h1>a, #main h2>a, #main h3>a {
-   color: inherit;
-   text-decoration: none;
+#main h1 > a,
+#main h2 > a,
+#main h3 > a {
+  color: inherit;
+  text-decoration: none;
 }
 
 li p {
-   margin: 0
+  margin: 0;
 }
 
-/* Dropdown hover effect */
-.dropdown:hover .dropdown-menu {
-   display: block;
+/* ===== Responsive ===== */
+@media (max-width: 768px) {
+  .hero {
+    padding: 2.5rem 1rem 2rem;
+  }
+
+  .hero h1 {
+    font-size: 2rem;
+  }
+
+  .footer-links {
+    flex-direction: column;
+    align-items: center;
+    gap: 0.75rem;
+  }
 }

--- a/_layout/foot.html
+++ b/_layout/foot.html
@@ -6,27 +6,59 @@
         {{ insert foot_highlight.html }}
     {{ end }}
 
-    <footer id=footer class="mt-auto text-center text-muted">
-        <div class=container>Made with <a href=https://franklinjl.org>Franklin.jl</a> and <a href=https://julialang.org>the Julia programming language</a>.</div>
+    <footer id=footer class="mt-auto">
+        <div class="container text-center">
+            <ul class="footer-links">
+                <li><a href="https://github.com/JuliaGPU">GitHub</a></li>
+                <li><a href="https://discourse.julialang.org/c/domain/gpu/11">Discourse</a></li>
+                <li><a href="https://julialang.slack.com/messages/C689Y34LE/">Slack #gpu</a></li>
+                <li><a href="/post/index.xml">RSS Feed</a></li>
+                <li><a href="/post/">Blog</a></li>
+                <li><a href="/learn/">Learn</a></li>
+            </ul>
+            <p style="font-size:0.85rem">
+                Made with <a href=https://franklinjl.org>Franklin.jl</a> and
+                <a href=https://julialang.org>the Julia programming language</a>.
+            </p>
+        </div>
     </footer>
 
-    <!-- FEATHER -->
-    <script src="https://cdn.jsdelivr.net/npm/feather-icons@4.29.2/dist/feather.min.js"></script>
-    <script>feather.replace()</script>
+    <!-- LUCIDE ICONS -->
+    <script src="https://cdn.jsdelivr.net/npm/lucide@0.344.0/dist/umd/lucide.min.js"></script>
+    <script>lucide.createIcons();</script>
 
     <!-- BOOTSTRAP -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>
 
-    <!-- GOOGLE ANALYTICS -->
+    <!-- DARK MODE TOGGLE -->
     <script>
-    window.ga = window.ga || function() {
-        (ga.q = ga.q || []).push(arguments)
-    };
-    ga.l = +new Date;
-    ga('create', 'UA-154489943-1', 'auto');
-    ga('send', 'pageview');
+    (function() {
+        var toggle = document.getElementById('theme-toggle');
+        var iconDark = document.getElementById('theme-icon-dark');
+        var iconLight = document.getElementById('theme-icon-light');
+
+        function updateIcons() {
+            var theme = document.documentElement.getAttribute('data-bs-theme');
+            if (theme === 'dark') {
+                iconDark.style.display = 'none';
+                iconLight.style.display = 'inline';
+            } else {
+                iconDark.style.display = 'inline';
+                iconLight.style.display = 'none';
+            }
+        }
+
+        updateIcons();
+
+        toggle.addEventListener('click', function() {
+            var current = document.documentElement.getAttribute('data-bs-theme');
+            var next = current === 'dark' ? 'light' : 'dark';
+            document.documentElement.setAttribute('data-bs-theme', next);
+            localStorage.setItem('theme', next);
+            updateIcons();
+        });
+    })();
     </script>
-    <script async src=https://www.google-analytics.com/analytics.js></script>
 
   </body>
 </html>

--- a/_layout/head.html
+++ b/_layout/head.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" class=h-100>
+<html lang="en" class=h-100 data-bs-theme="light">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no">
@@ -7,10 +7,33 @@
   <link rel="icon" href="/assets/favicon.ico">
   <link rel="alternate" type="application/rss+xml" href="/post/index.xml" title="RSS Feed for JuliaGPU">
 
+  <!-- Open Graph / Social -->
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="JuliaGPU">
+  <meta property="og:image" content="https://juliagpu.org/assets/logo_crop.png">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:image" content="https://juliagpu.org/assets/logo_crop.png">
+  {{ispage index.html}}
+    <meta property="og:title" content="JuliaGPU">
+    <meta property="og:description" content="High-performance GPU programming in a high-level language.">
+  {{end}}
+  {{isnotpage index.html}}
+    <meta property="og:title" content="{{title}} - JuliaGPU">
+    <meta property="og:description" content="{{title}} - JuliaGPU">
+  {{end}}
+
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css">
   {{if hascode}} {{insert head_highlight.html }} {{end}}
 
   <link rel="stylesheet" href="/css/style.css">
+
+  <!-- Dark mode: apply saved preference before paint -->
+  <script>
+    (function() {
+      var theme = localStorage.getItem('theme') || 'light';
+      document.documentElement.setAttribute('data-bs-theme', theme);
+    })();
+  </script>
 
   {{ispage index.html}}
     <title>JuliaGPU</title>

--- a/_layout/head_highlight.html
+++ b/_layout/head_highlight.html
@@ -1,1 +1,1 @@
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/styles/default.min.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/styles/atom-one-dark.min.css">

--- a/_layout/header.html
+++ b/_layout/header.html
@@ -1,28 +1,27 @@
 <div id=nav-border class=container>
-    <nav class="navbar navbar-expand-sm navbar-light">
+    <nav class="navbar navbar-expand-md">
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
-            aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle
-navigation">
+            aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
         </button>
         <div class="collapse navbar-collapse justify-content-center" id="navbarNav">
             <ul class=navbar-nav>
                 <li class="nav-item">
-                    <a class="nav-link {{ispage index}}active{{end}}" href="/"><i data-feather=home></i> Home</a>
+                    <a class="nav-link {{ispage index}}active{{end}}" href="/">Home</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link {{ispage post/*}}active{{end}}" href="/post/"><i data-feather=file-text></i> News</a>
+                    <a class="nav-link {{ispage post/*}}active{{end}}" href="/post/">Blog</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link {{ispage showcases}}active{{end}}" href="/showcases/"><i data-feather=star></i> Showcases</a>
+                    <a class="nav-link {{ispage showcases}}active{{end}}" href="/showcases/">Showcases</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link {{ispage learn}}active{{end}}" href="/learn/"><i data-feather=book-open></i> Learn</a>
+                    <a class="nav-link {{ispage learn}}active{{end}}" href="/learn/">Learn</a>
                 </li>
                 <li class="nav-item dropdown">
                     <a class="nav-link dropdown-toggle {{ispage backends/*}}active{{end}}" href="#" id="backendDropdown"
                         role="button" data-bs-toggle="dropdown" aria-expanded="false">
-                        <i data-feather=cpu></i> Backends
+                        Backends
                     </a>
                     <div class="dropdown-menu" aria-labelledby="backendDropdown">
                         <a class="dropdown-item {{ispage backends/cuda}}active{{end}}" href="/backends/cuda/">CUDA</a>
@@ -33,6 +32,12 @@ navigation">
                     </div>
                 </li>
             </ul>
+            <div class="ms-md-3">
+                <button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark mode">
+                    <i data-lucide=moon id="theme-icon-dark" style="display:none"></i>
+                    <i data-lucide=sun id="theme-icon-light" style="display:none"></i>
+                </button>
+            </div>
         </div>
     </nav>
 </div>

--- a/index.md
+++ b/index.md
@@ -1,17 +1,25 @@
 +++
 title = "JuliaGPU"
+hascode = true
 +++
 
 ~~~
-<div class="p-5 mb-5">
-  <div class="container text-center">
+<div class="hero">
+  <div class="container">
     <h1>
-      <img height=70 src="/assets/logo_crop.png">
+      <img height=70 src="/assets/logo_crop.png" alt="JuliaGPU">
       JuliaGPU
     </h1>
-    <p class="font-125">
+    <p class="lead">
       High-performance GPU programming in a high-level language.
     </p>
+    <div class="hero-code">
+      <pre><code class="language-julia">using CUDA
+
+A = CUDA.randn(1024, 1024)
+B = CUDA.randn(1024, 1024)
+C = A * B  # runs on the GPU</code></pre>
+    </div>
   </div>
 </div>
 ~~~
@@ -24,6 +32,68 @@ without sacrificing performance**.
 Many applications and libraries in the Julia ecosystem rely on GPU support, and
 the number is growing rapidly. Head over to the [showcases](/showcases/) page
 if you want to see some examples of how Julia's GPU support is used in practice.
+
+
+## Platform comparison
+
+~~~
+<div class="table-responsive">
+<table class="backend-table">
+  <thead>
+    <tr>
+      <th>Platform</th>
+      <th>Package</th>
+      <th>Maturity</th>
+      <th>Array Type</th>
+      <th>Kernel Macro</th>
+      <th>Vendor Libraries</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><a href="/backends/cuda/">NVIDIA CUDA</a></td>
+      <td><a href="https://github.com/JuliaGPU/CUDA.jl">CUDA.jl</a></td>
+      <td><span class="badge badge-mature">Mature</span></td>
+      <td><code>CuArray</code></td>
+      <td><code>@cuda</code></td>
+      <td>cuBLAS, cuFFT, cuDNN, cuSOLVER, cuSPARSE, cuTENSOR</td>
+    </tr>
+    <tr>
+      <td><a href="/backends/rocm/">AMD ROCm</a></td>
+      <td><a href="https://github.com/JuliaGPU/AMDGPU.jl">AMDGPU.jl</a></td>
+      <td><span class="badge badge-stable">Stable</span></td>
+      <td><code>ROCArray</code></td>
+      <td><code>@roc</code></td>
+      <td>rocBLAS, rocFFT, rocSOLVER, rocSPARSE</td>
+    </tr>
+    <tr>
+      <td><a href="/backends/oneapi/">Intel oneAPI</a></td>
+      <td><a href="https://github.com/JuliaGPU/oneAPI.jl">oneAPI.jl</a></td>
+      <td><span class="badge badge-developing">Developing</span></td>
+      <td><code>oneArray</code></td>
+      <td><code>@oneapi</code></td>
+      <td>oneMKL (partial)</td>
+    </tr>
+    <tr>
+      <td><a href="/backends/metal/">Apple Metal</a></td>
+      <td><a href="https://github.com/JuliaGPU/Metal.jl">Metal.jl</a></td>
+      <td><span class="badge badge-stable">Stable</span></td>
+      <td><code>MtlArray</code></td>
+      <td><code>@metal</code></td>
+      <td>MPS (partial)</td>
+    </tr>
+    <tr>
+      <td><a href="/backends/opencl/">OpenCL</a></td>
+      <td><a href="https://github.com/JuliaGPU/OpenCL.jl">OpenCL.jl</a></td>
+      <td><span class="badge badge-early">Pre-release</span></td>
+      <td><code>CLArray</code></td>
+      <td><code>@opencl</code></td>
+      <td>&mdash;</td>
+    </tr>
+  </tbody>
+</table>
+</div>
+~~~
 
 
 ## Supported platforms

--- a/post/index.md
+++ b/post/index.md
@@ -57,7 +57,7 @@ external_entries = [
 ~~~
 <h1>
   Blog
-  <a href=/post/index.xml><i data-feather=rss></i></a>
+  <a href=/post/index.xml><i data-lucide=rss></i></a>
 </h1>
 ~~~
 

--- a/utils.jl
+++ b/utils.jl
@@ -46,12 +46,12 @@ function hfun_post_date()
     author_line = ""
     if !isnothing(author)
         author_line = """
-            <i data-feather=edit-2></i>
+            <i data-lucide=pencil></i>
             $author
             """
     end
     return """
-           <i data-feather=calendar></i>
+           <i data-lucide=calendar></i>
            <time datetime=$y-$m-$d>$(MONTH[m]) $d, $y</time><br>
            $author_line
            """
@@ -59,14 +59,14 @@ end
 
 function blogpost_entry_html(link, title, y, m, d; ext=false)
     return """
-        <p>
+        <div class="blog-entry">
           <a class=font-125 href="$link">
             $title
           </a>$(ifelse(ext, "<span>&nbsp;&#8599;</span>", ""))
           <br>
-          <i data-feather=calendar></i>
-          <time datetime=$y-$m-$d>$(MONTH[m]) $d, $y</time><br>
-        </p>
+          <i data-lucide=calendar style="width:14px;height:14px"></i>
+          <time datetime=$y-$m-$d>$(MONTH[m]) $d, $y</time>
+        </div>
         """
 end
 
@@ -80,7 +80,11 @@ function blogpost_entry(fpath)
         return nothing
     end
     ext = something(pagevar(rpath, :external), false)
-    title = pagevar(rpath, :title)::String
+    title = pagevar(rpath, :title)
+    if title === nothing
+        return nothing
+    end
+    title = title::String
     y, m, d = getdate(fpath)
     rpath = replace(fpath, r"\.md$" => "")
     date = Date(y, m, d)


### PR DESCRIPTION
## Summary
- Add dark mode toggle, expanded layout (860px), and JuliaGPU-branded color palette
- New homepage hero with code example and backend comparison table
- Switch to Atom One Dark code theme, Lucide Icons, OG/Twitter meta tags
- Expanded footer with community links, blog entries as styled cards
- Remove deprecated Universal Analytics and search bar
- Rename News to Blog in navbar
- Upgrade Julia 1.9 → 1.12 and Franklin 0.10.35 → 0.10.97

## Test plan
- [ ] Verify site builds successfully in CI
- [ ] Check PR preview deployment renders correctly
- [ ] Test dark mode toggle and persistence across page loads
- [ ] Check backend comparison table on homepage
- [ ] Confirm responsive layout on mobile viewports
- [ ] Verify code blocks use dark theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)